### PR TITLE
modify: Add diff mode keybindings to example .tigrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,21 @@ tig-rebase.sh fixup|ascend|descend|reword|abort HASH
 ```
 # Fixup with parent commit
 bind main <Ctrl-f> !tig-rebase.sh fixup %(commit)
+bind diff <Ctrl-f> !tig-rebase.sh fixup %(commit)
 
 # Rebase to move commit up
 bind main <Ctrl-k> !tig-rebase.sh ascend %(commit)
+bind diff <Ctrl-k> !tig-rebase.sh ascend %(commit)
 
 # Rebase to move commit down
 bind main <Ctrl-j> !tig-rebase.sh descend %(commit)
+bind diff <Ctrl-j> !tig-rebase.sh descend %(commit)
 
 # Edit commit message
 bind main <Ctrl-r> !tig-rebase.sh reword %(commit)
+bind diff <Ctrl-r> !tig-rebase.sh reword %(commit)
 
 # Abort current rebase
 bind main <Ctrl-x> !tig-rebase.sh abort
+bind diff <Ctrl-x> !tig-rebase.sh abort
 ```


### PR DESCRIPTION
When reviewing commits using tig, you typically open the diff pane for a
commit by pressing enter. With the current example, the tig-rebase
keybindings did not work in this mode, but adding extra bind directives
fixes this.
