### PR TITLE
Update script for newest git 2.11 version

### DIFF
--- a/tig-rebase.sh
+++ b/tig-rebase.sh
@@ -20,7 +20,7 @@ case $action in
             if [ -z $commit ]; then
                 usage
             else
-                current=${commit:0:7}
+                current=$(git log --pretty=format:%h "$commit" -1)
                 parent=$(git log --pretty=format:%h ${current}~1 -1)
                 child=$(git log --pretty=format:%h --reverse --ancestry-path ${current}..HEAD | head -n 1)
             fi


### PR DESCRIPTION
Since git now has variable width id (depending on repository size), instead of hardcoding a length of 7, we should let git give us the "normalized" git hash