### PR TITLE
Add keybinding to create a new fixup commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,8 @@ bind diff <Ctrl-r> !tig-rebase.sh reword %(commit)
 bind main <Ctrl-x> !tig-rebase.sh abort
 bind diff <Ctrl-x> !tig-rebase.sh abort
 ```
+# Create fixup commit from current staged changes (no rebase happens
+# here, this just creates a commit to fix the selected commit)
+bind main <Ctrl-F> !git commit --fixup %(commit)
+bind diff <Ctrl-F> !git commit --fixup %(commit)
+


### PR DESCRIPTION
This technically does not use tig-rebase.sh or run a rebase, but does
seem like it would fit the list of keybindings.

Not sure if this is really something to document here, so feel free to reject this :-)